### PR TITLE
Fix Android text paddings

### DIFF
--- a/src/input/index.tsx
+++ b/src/input/index.tsx
@@ -55,6 +55,7 @@ const styles = StyleSheet.create({
 		flex: 1,
 		paddingHorizontal: 15,
 		height: 34,
-		fontSize: 16
+		fontSize: 16,
+		padding: 0
 	}
 })

--- a/src/sectionHeader/index.tsx
+++ b/src/sectionHeader/index.tsx
@@ -12,7 +12,7 @@ const SectionHeader = ({name}: { name: string }) => {
 }
 
 const styles = StyleSheet.create({
-	sectionHeader: {margin: 8, fontSize: 17, height: 20, width: '100%', color: '#999'}
+	sectionHeader: {margin: 8, fontSize: 17, width: '100%', color: '#999'}
 })
 
 export default memo(SectionHeader)


### PR DESCRIPTION
Fix 
1. Android textinput has default padding, fix by setting it to 0
2. Android section title text cut off, remote `height` in style as it'll automatically adjust

From
<img src="https://github.com/woodybury/rn-emoji-picker/assets/86952204/06e943b2-59f5-41fa-9271-ddfd4565bb56" width="300"/>

To
<img src="https://github.com/woodybury/rn-emoji-picker/assets/86952204/e058beed-eb3d-416e-83f5-71dd786cffad" width="300"/>
